### PR TITLE
解决persistentId不存在时NPE

### DIFF
--- a/src/com/pili/Stream.java
+++ b/src/com/pili/Stream.java
@@ -266,7 +266,7 @@ public final class Stream {
 
         public SnapshotResponse(JsonObject jsonObj) {
             targetUrl = jsonObj.get("targetUrl").getAsString();
-            persistentId = jsonObj.get("persistentId").getAsString();
+            persistentId = jsonObj.get("persistentId")==null?null:jsonObj.get("persistentId").getAsString();
             mJsonString = jsonObj.toString();
         }
 


### PR DESCRIPTION
当Stream.snapshot()中不传notifyUrl参数时，SnapshotResponse抛出NPE
